### PR TITLE
add support for mockingbot.com

### DIFF
--- a/SketchI18N.sketchplugin/Contents/Resources/i18n/zh-Hans.json
+++ b/SketchI18N.sketchplugin/Contents/Resources/i18n/zh-Hans.json
@@ -1518,5 +1518,7 @@
     "Rename Selected Instances": "重命名所选实例",
     "Rename All Instances": "重命名全部实例",
     "Rename Instances of Selected Symbols": "重命名所选组件的实例",
-    "Rename All Instances on Current Page": "重命名当前页面全部实例"
+    "Rename All Instances on Current Page": "重命名当前页面全部实例",
+
+    "Export to MockingBot": "导出选中的画板到墨刀"
 }

--- a/SketchI18N.sketchplugin/Contents/Resources/i18n/zh-Hant.json
+++ b/SketchI18N.sketchplugin/Contents/Resources/i18n/zh-Hant.json
@@ -1518,5 +1518,7 @@
     "Rename Selected Instances": "重新命名所選例項",
     "Rename All Instances": "重新命名全部例項",
     "Rename Instances of Selected Symbols": "重新命名所選元件的例項",
-    "Rename All Instances on Current Page": "重新命名當前頁面全部例項"
+    "Rename All Instances on Current Page": "重新命名當前頁面全部例項",
+
+    "Export to MockingBot": "導出選中的畫板到墨刀"
 }


### PR DESCRIPTION
This PR is going to add support for mockingbot.com(en), modao.cc(zh).

We are an online prototyping platform and just building a plugin for Sketch.app, you can find more [here](https://mockingbot.com/sketch).

We want to add SketchI18N support for our plugin. Pls support us.